### PR TITLE
Sticky headers

### DIFF
--- a/renderer/views/components/table.js
+++ b/renderer/views/components/table.js
@@ -18,22 +18,22 @@ const style = css`
     text-align: left;
   }
 
-  tr:nth-child(even), thead {
+  .mediaList tr:nth-child(even), thead {
     background: var(--lighten);
   }
 
-  th {
+  .mediaList th {
     font-weight: var(--font-weight-default);
     border-right: var(--border);
     border-bottom: var(--border);
   }
 
-  td, th {
+  .mediaList td, th {
     padding: 2px 15px;
   }
 
-  thead th:active,
-  tbody tr:active {
+  .mediaList thead th:active,
+  .mediaList tbody tr:active {
     background: var(--light);
   }
 

--- a/renderer/views/components/table.js
+++ b/renderer/views/components/table.js
@@ -5,8 +5,9 @@ const css = require('csjs-inject')
 const style = css`
   .pane {
     flex: 1 0;
-    overflow-y: overlay;
-    height: 100%;
+    overflow-y: hidden;
+    display: flex;
+    flex-direction: column;
   }
 
   .mediaList {
@@ -16,6 +17,12 @@ const style = css`
     border: 0;
     border-collapse: separate;
     text-align: left;
+  }
+
+  .mediaList td {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .mediaList tr:nth-child(even), thead {
@@ -37,29 +44,47 @@ const style = css`
     background: var(--light);
   }
 
+  .tableHeader {
+    flex: 0 0;
+  }
+
+  .tableBody {
+    flex: 1 0;
+    overflow: overlay;
+  }
+
   /* note: sticky table header
   https://codepen.io/tjvantoll/pen/JEKIu
   */
 
+  /* use colgroup to sanely apply width properties  */
+  /* https://docs.webplatform.org/wiki/html/elements/colgroup */
+
   .mediaList  .time {
     text-align: right;
-    max-width: 5em;
+    width: 6em;
   }
 `
 
 module.exports = (state, prev, send) => html`
   <section class="${style.pane}">
-    <table class="${style.mediaList}">
-      <thead>
-        <tr>
-          <th>Title</th>
-          <th class="${style.time}">Time</th>
-          <th>Artist</th>
-          <th>Album</th>
-        </tr>
-      </thead>
-      <tbody>${renderList(state, send)}</tbody>
-    </table>
+    <div class=${style.tableHeader}>
+      <table class="${style.mediaList}">
+        <thead>
+          <tr>
+            <th>Title</th>
+            <th class="${style.time}">Time</th>
+            <th>Artist</th>
+            <th>Album</th>
+          </tr>
+        </thead>
+      </table>
+    </div>
+    <div class=${style.tableBody}>
+      <table class="${style.mediaList} ${style.tableBody}">
+        <tbody>${renderList(state, send)}</tbody>
+      </table>
+    </div>
   </section>
 `
 


### PR DESCRIPTION
This is the least hacky way I could find to do this.  I looked at

- https://jsfiddle.net/purmou/npdob14y/4/
- https://codepen.io/tjvantoll/pen/JEKIu

We can probably use colgroup to set state sanely between the two tables
but we might not even have to because they seem to be tracking the same
widths.

- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table
- https://docs.webplatform.org/wiki/html/elements/colgroup

closes https://github.com/hypermodules/hyperamp/issues/17

Also, it looks like overflow results in a slight x axis scroll amount.  A little janky.