### PR TITLE
manage window state on player

### DIFF
--- a/main/player.js
+++ b/main/player.js
@@ -1,19 +1,27 @@
 var { BrowserWindow } = require('electron')
+var windowStateKeeper = require('electron-window-state')
 var path = require('path')
 var PLAYER_WINDOW = 'file://' + path.resolve(__dirname, '..', 'renderer', 'index.html')
 var player = module.exports = {
   init,
-  win: null
+  win: null,
+  windowState: null
 }
 
 require('electron-debug')({ showDevTools: true })
 require('electron-context-menu')()
 
 function init () {
+  player.windowState = windowStateKeeper({
+    width: 800,
+    height: 600
+  })
   var win = player.win = new BrowserWindow({
     title: 'Hyper Amp',
-    width: 800,
-    height: 600,
+    x: player.windowState.x,
+    y: player.windowState.y,
+    width: player.windowState.width,
+    height: player.windowState.height,
     minWidth: 275,
     minHeight: 40,
     titleBarStyle: 'hidden-inset',
@@ -21,6 +29,8 @@ function init () {
     show: false,
     thickFrame: true
   })
+
+  player.windowState.manage(win)
 
   win.loadURL(PLAYER_WINDOW)
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "electron-config": "^0.2.1",
     "electron-context-menu": "^0.8.0",
     "electron-debug": "^1.0.1",
+    "electron-window-state": "^4.0.2",
     "entypo": "^2.0.0",
     "folder-walker": "^3.0.0",
     "format-duration": "^1.0.0",


### PR DESCRIPTION
Closes https://github.com/hypermodules/hyperamp/issues/90

This remembers the player window when you close it and open it.  Eventually should probably save it on quit, but for now this is better than before.