### PR TITLE
Implement naive shuffle

### DIFF
--- a/main/index.js
+++ b/main/index.js
@@ -16,12 +16,14 @@ var state = xtend({
   paths: [], // USERCONFIG: Paths for seraching for songs
   trackDict: {}, // object of known tracks
   trackOrder: [], // array of track keys
+  trackShuffle: [], // array of track keys, shuffled
   currentIndex: null, // Currently queued track index
   loading: false, // Mutex for performing a scan for new tracks
   search: '', // search string used to derive current trackOrder
   volume: 0.50,
   playing: false,
   muted: false,
+  shuffling: true,
   artwork: null
 }, persist.store, userConfig.store)
 
@@ -140,6 +142,20 @@ app.on('ready', () => {
     // audio -> player
     state.currentTime = currentTime
     if (player.win) player.win.send('timeupdate', currentTime)
+  }
+
+  ipcMain.on('shuffle', shuffle)
+
+  function shuffle (ev) {
+    state.shuffling = true
+    if (player.win) player.win.send('shuffle')
+  }
+
+  ipcMain.on('unshuffle', unshuffle)
+
+  function unshuffle (ev) {
+    state.shuffling = false
+    if (player.win) player.win.send('unshuffle')
   }
 
   ipcMain.on('timeupdate', timeupdate)

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "folder-walker": "^3.0.0",
     "format-duration": "^1.0.0",
     "from2": "^2.3.0",
+    "fy-shuffle": "^1.0.0",
     "global": "^4.3.2",
     "lodash.debounce": "^4.0.8",
     "lodash.get": "^4.4.2",

--- a/renderer/elements/player/index.js
+++ b/renderer/elements/player/index.js
@@ -35,6 +35,7 @@ function PlayerControls (opts) {
   this._handlePrev = this._handlePrev.bind(this)
   this._handleNext = this._handleNext.bind(this)
   this._handlePlayPause = this._handlePlayPause.bind(this)
+  this._shuffleToggle = this._shuffleToggle.bind(this)
 
   // Owned Children
   this._positionSlider = new Range(this._opts)
@@ -65,11 +66,17 @@ PlayerControls.prototype._handlePlayPause = function () {
   else this._emit('player:play')
 }
 
+PlayerControls.prototype._shuffleToggle = function () {
+  if (this._shuffling) this._emit('player:unshuffle')
+  else this._emit('player:shuffle')
+}
+
 PlayerControls.prototype._render = function (state, emit) {
   assert.equal(typeof emit, 'function', 'PlaybackCluster: emit should be a function')
   this._emit = emit
   this._currentIndex = state.player.currentIndex
   this._playing = state.player.playing
+  this._shuffling = state.player.shuffling
   this._position = state.player.currentTime
   var key = state.library.trackOrder[this._currentIndex]
   var track = state.library.trackDict[key]
@@ -100,6 +107,13 @@ PlayerControls.prototype._render = function (state, emit) {
           iconName: 'entypo-controller-fast-forward'
         })}
       </div>
+      <div class="${buttonStyles.btnGroup} ${styles.smallButtons}">
+        ${button({
+          onclick: this._shuffleToggle,
+          iconName: 'entypo-shuffle',
+          className: state.player.shuffling ? null : styles.disabled
+        })}
+      </div>
     </div>
 `
 }
@@ -110,5 +124,6 @@ PlayerControls.prototype._update = function (state, emit) {
   if (this._playing !== state.player.playing) return true
   if (this._position !== state.player.currentTime) return true
   if (this._disabled !== truthy(state.player.currentIndex)) return true
+  if (this._shuffling !== state.player.shuffling) return true
   return false
 }

--- a/renderer/elements/player/styles.js
+++ b/renderer/elements/player/styles.js
@@ -17,4 +17,14 @@ module.exports = css`
     width: 100%;
   }
   .trackControls { flex: 1 }
+
+  .smallButtons {
+    font-size: 0.5em;
+  }
+
+  .disabled svg {
+    fill: rgb(144, 144, 144);
+  }
 `
+
+// TODO clean up these styles for shuffle byttons

--- a/renderer/stores/player.js
+++ b/renderer/stores/player.js
@@ -13,6 +13,7 @@ function playerStore (state, emitter) {
     localState.volume = 0.50
     localState.muted = false
     localState.artwork = null
+    localState.shuffling = false
   }
 
   function muted (bool) {
@@ -22,6 +23,11 @@ function playerStore (state, emitter) {
 
   function playing (bool) {
     localState.playing = bool
+    emitter.emit('render')
+  }
+
+  function shuffling (bool) {
+    localState.shuffling = bool
     emitter.emit('render')
   }
 
@@ -49,6 +55,8 @@ function playerStore (state, emitter) {
   emitter.on('player:next', next)
   emitter.on('player:mute', mute)
   emitter.on('player:unmute', unmute)
+  emitter.on('player:shuffle', shuffle)
+  emitter.on('player:unshuffle', unshuffle)
   emitter.on('player:seek', seek)
   emitter.on('player:changeVolume', changeVolume)
   emitter.on('player:sync-state', syncState)
@@ -91,6 +99,16 @@ function playerStore (state, emitter) {
     muted(false)
   }
 
+  function shuffle () {
+    ipcRenderer.send('shuffle')
+    shuffling(true)
+  }
+
+  function unshuffle () {
+    shuffling(false)
+    ipcRenderer.send('unshuffle')
+  }
+
   function seek (time) {
     window.requestAnimationFrame(() => {
       ipcRenderer.send('seek', time)
@@ -114,6 +132,7 @@ function playerStore (state, emitter) {
     localState.currentIndex = mainState.currentIndex
     localState.volume = mainState.volume
     localState.muted = mainState.muted
+    localState.shuffling = mainState.shuffling
     localState.artwork = mainState.artwork
     emitter.emit('render')
   }
@@ -123,6 +142,8 @@ function playerStore (state, emitter) {
   ipcRenderer.on('queue', (ev, newIndex) => current(newIndex))
   ipcRenderer.on('mute', () => muted(true))
   ipcRenderer.on('unmute', () => muted(false))
+  ipcRenderer.on('shuffle', () => shuffling(true))
+  ipcRenderer.on('unshuffle', () => shuffling(false))
   ipcRenderer.on('volume', (ev, lev) => volume(lev))
   ipcRenderer.on('artwork', (ev, blobPath) => updateArtwork(blobPath))
   ipcRenderer.on('timeupdate', (ev, time) => {

--- a/renderer/stores/player.js
+++ b/renderer/stores/player.js
@@ -28,7 +28,6 @@ function playerStore (state, emitter) {
 
   function shuffling (bool) {
     localState.shuffling = bool
-    emitter.emit('render')
   }
 
   function currentTime (time, shouldRender) {
@@ -102,11 +101,13 @@ function playerStore (state, emitter) {
   function shuffle () {
     ipcRenderer.send('shuffle')
     shuffling(true)
+    emitter.emit('render')
   }
 
   function unshuffle () {
-    shuffling(false)
     ipcRenderer.send('unshuffle')
+    shuffling(false)
+    emitter.emit('render')
   }
 
   function seek (time) {


### PR DESCRIPTION
This is a super simple shuffle mode.  Similar to https://github.com/hypermodules/hyperamp/issues/191, now playing state is not properly transformed between shuffle / sort modes.  I didn't have time to do a full proper implementation that would cover that use case, but this way you can at least filter and shuffle a music library.