### PR TITLE
add clear script

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
     "test:renderer": "tape renderer/**/test.js | tap-format-spec",
     "rebuild": "electron-rebuild",
     "build": "build --dir",
-    "dist": "build"
+    "dist": "build",
+    "clear": "electron scripts/clear.js"
   },
   "build": {
     "appId": "com.hypermodules.hyperamp",

--- a/scripts/clear.js
+++ b/scripts/clear.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env electron
+
+var Store = require('electron-store')
+
+var config = new Store({ name: 'hyperamp-config' })
+var persist = new Store({ name: 'hyperamp-persist' })
+
+console.log('clearing %s', config.path)
+config.clear()
+
+console.log('clearing %s', persist.path)
+persist.clear()
+
+process.exit(0)


### PR DESCRIPTION
Adds a script to clear config & persist stores in user data.

```
npm run clear
```

or

```sh
./scripts/clear.js # electron must be in PATH for this one to work
```

btw why do we have two different stores?