### PR TITLE
Propagate loading state to UI

### DIFF
--- a/main/index.js
+++ b/main/index.js
@@ -175,6 +175,7 @@ app.on('ready', function appReady () {
 
   function handleNewTracks (err, newTrackDict) {
     state.loading = false
+    broadcast('loading', false)
     if (err) return console.warn(err)
     state.trackDict = newTrackDict
     var newTrackOrder = state.trackOrder = Object.keys(newTrackDict)
@@ -189,6 +190,7 @@ app.on('ready', function appReady () {
     state.paths = paths
     state.loading = makeTrackDict(paths, handleNewTracks)
     console.log('scanning ' + paths)
+    broadcast('loading', true)
   })
 
   function search (ev, searchString) {

--- a/renderer/elements/header/index.js
+++ b/renderer/elements/header/index.js
@@ -57,6 +57,7 @@ Header.prototype._handleNav = function () {
 Header.prototype._render = function (state, emit) {
   this._emit = emit
   this._search = state.library.search
+  this._loading = state.library.loading
   return html`
     <header class="${styles.toolbar}">
       <div class="${styles.leftCluster}">
@@ -72,6 +73,7 @@ Header.prototype._render = function (state, emit) {
             iconName: 'entypo-plus'
           })}
           ${button({
+            className: this._loading ? styles.spin : null,
             onclick: this._handleNav,
             iconName: 'entypo-cog'
           })}
@@ -83,6 +85,7 @@ Header.prototype._render = function (state, emit) {
 
 Header.prototype._update = function (state, emit) {
   if (this._search !== state.library.search) return true
+  if (this._loading !== state.library.loading) return true
   return false
 }
 

--- a/renderer/elements/header/styles.js
+++ b/renderer/elements/header/styles.js
@@ -26,4 +26,17 @@ module.exports = css`
     margin-right: 1em;
     height: 24px;
   }
+
+  @keyframes ckw {
+    0% {
+        transform: rotate(0deg);
+    }
+    100% {
+        transform: rotate(360deg);
+    }
+  }
+
+  .spin {
+    animation: ckw 4s infinite linear;
+  }
 `

--- a/renderer/stores/library.js
+++ b/renderer/stores/library.js
@@ -12,6 +12,7 @@ function libraryStore (state, emitter) {
     localState.trackOrder = []
     localState.search = ''
     localState.selectedIndex = null
+    localState.loading = false
   }
 
   emitter.on('library:search', search)
@@ -31,6 +32,11 @@ function libraryStore (state, emitter) {
 
   function updatePaths (newPaths) {
     localState.paths = newPaths
+  }
+
+  function loading (bool) {
+    localState.loading = bool
+    emitter.emit('render')
   }
 
   function updateLibrary (paths) {
@@ -55,10 +61,12 @@ function libraryStore (state, emitter) {
       localState.search = mainState.search
       localState.trackDict = mainState.trackDict
       localState.trackOrder = mainState.trackOrder
+      localState.loading = mainState.loading
       emitter.emit('render')
     })
   }
 
+  ipcRenderer.on('loading', (ev, isLoading) => loading(isLoading))
   ipcRenderer.on('sync-state', syncState)
   ipcRenderer.on('track-dict', (ev, newTrackDict, newTrackOrder, newPaths) => {
     window.requestAnimationFrame(() => {


### PR DESCRIPTION
Contributes to the closing of https://github.com/hypermodules/hyperamp/issues/192 by passing main state to the main window.

@ungoldman I wasn't sure how the loader worked, but I suggest rebasing that branch to make sure you are using the latest deps.  I fixed some critical rendering bugs with cache-component. 