### PR TITLE
fix: omit duplicate timeupdate events

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "musicmetadata": "^2.0.4",
     "nanobus": "^4.1.0",
     "nanocomponent": "^6.0.0",
-    "nanologger": "^1.0.2",
+    "nanologger": "^1.3.0",
     "nanotick": "^1.1.6",
     "pump": "^1.0.2",
     "run-parallel": "^1.1.6",

--- a/renderer/audio/audio-player.js
+++ b/renderer/audio/audio-player.js
@@ -22,16 +22,21 @@ function AudioPlayer (audioNode, state) {
   this.audio.muted = state.muted
   this.seeking = false
   this.seekDebounceTimer = null
+  this.timeupdate = null
 
   this._endedListener = this.audio.addEventListener('ended', function () {
     if (!self.seeking) self.emit('ended')
   })
 
   this._timeListener = this.audio.addEventListener('timeupdate', function (ev) {
-    if (!self.seeking) self.emit('timeupdate', self.audio.currentTime)
+    if (self.seeking) return
+    var timeupdate = Math.floor(self.audio.currentTime)
+    if (self.timeupdate === timeupdate) return
+    self.timeupdate = timeupdate
+    self.emit('timeupdate', self.timeupdate)
   })
 
-  console.log(this)
+  this.emit('initialized', this)
 }
 
 AudioPlayer.prototype = Object.create(Nanobus.prototype)
@@ -41,7 +46,7 @@ AudioPlayer.prototype.seekDebounce = function () {
   if (this.seekDebounceTimer) clearTimeout(this.seekDebounceTimer)
   var self = this
   this.seekDebounceTimer = setTimeout(function () {
-    console.log('debounce cleared')
+    self.emit('debounce cleared')
     self.seeking = false
     self.seekDebounceTimer = null
     // TODO: check if we are at the end and we lost the endedEvent
@@ -89,13 +94,13 @@ AudioPlayer.prototype.seek = function (newTime) {
 }
 
 AudioPlayer.prototype.updateTrackDict = function (trackDict, trackOrder) {
-  console.log(arguments)
+  this.emit('updateTrackDict', arguments)
   this.trackDict = trackDict
   this.trackOrder = trackOrder
 }
 
 AudioPlayer.prototype.updateTrackOrder = function (trackOrder) {
-  console.log(arguments)
+  this.emit('updateTrackOrder', arguments)
   this.trackOrder = trackOrder
 }
 

--- a/renderer/audio/index.js
+++ b/renderer/audio/index.js
@@ -13,6 +13,7 @@ var audioNode = document.querySelector('#audio')
 var player = window.player = new AudioPlayer(audioNode, mainState)
 
 player.on('*', function (event, data) {
+  if (data === undefined) return log.info(event)
   log.info(event, data)
 })
 

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -6,6 +6,6 @@
 </head>
 <body>
   <main id="app"></main>
-  <script src="./index.js"></script>
+  <script>require('./index.js')</script>
 </body>
 </html>

--- a/renderer/stores/config.js
+++ b/renderer/stores/config.js
@@ -8,7 +8,7 @@ function configStore (state, emitter) {
 
   if (!localState) {
     localState = state.config = {}
-    localState = config.store
+    localState = config.store // wtf
   }
 
   emitter.on('config:set', set)

--- a/renderer/stores/library.js
+++ b/renderer/stores/library.js
@@ -2,18 +2,20 @@ var ipcRenderer = require('electron').ipcRenderer
 
 module.exports = libraryStore
 
+function getInitialState () {
+  return {
+    paths: [],
+    trackDict: {},
+    trackOrder: [],
+    search: '',
+    selectedIndex: null,
+    loading: false
+  }
+}
+
 function libraryStore (state, emitter) {
   var localState = state.library
-
-  if (!localState) {
-    localState = state.library = {}
-    localState.paths = []
-    localState.trackDict = {}
-    localState.trackOrder = []
-    localState.search = ''
-    localState.selectedIndex = null
-    localState.loading = false
-  }
+  if (!localState) localState = state.library = getInitialState()
 
   emitter.on('library:search', search)
   emitter.on('library:update-library', updateLibrary)


### PR DESCRIPTION
Only emitting timeupdate events from audio when they are different from the last one. This way there is less unnecessary IPC communications, less unnecessary renders...

Also made the player logger a little nicer.

Also fiddled with initializing state in a couple stores.

Mostly just poking around and thinking about how to make the micro version of hyperamp we talked about a couple weekends ago.