### PR TITLE
feat: make columns togglable

### DIFF
--- a/renderer/elements/header/index.js
+++ b/renderer/elements/header/index.js
@@ -1,4 +1,4 @@
-var remote = require('electron').remote
+var { remote } = require('electron')
 var { app, dialog } = remote
 var html = require('choo/html')
 var Component = require('nanocomponent')

--- a/renderer/lib/constants.js
+++ b/renderer/lib/constants.js
@@ -1,0 +1,18 @@
+/**
+ * a place for constants that need to be used in more than one file
+ */
+
+// column names master list
+const COLUMNS = new Set([
+  'title',
+  'time',
+  'artist',
+  'album',
+  'track',
+  'disk',
+  'year'
+])
+
+module.exports = {
+  COLUMNS
+}

--- a/renderer/stores/library.js
+++ b/renderer/stores/library.js
@@ -1,5 +1,6 @@
 var ipcRenderer = require('electron').ipcRenderer
 var mousetrap = require('mousetrap')
+var { COLUMNS } = require('../lib/constants')
 
 module.exports = libraryStore
 
@@ -10,7 +11,11 @@ function getInitialState () {
     trackOrder: [],
     search: '',
     selectedIndex: null,
-    loading: false
+    loading: false,
+    columns: Array.from(COLUMNS).reduce((obj, col) => {
+      obj[col] = true
+      return obj
+    }, {})
   }
 }
 
@@ -55,6 +60,12 @@ function libraryStore (state, emitter) {
   emitter.on('library:track-order', updateTrackOrder)
   emitter.on('library:paths', updatePaths)
   emitter.on('library:select', select)
+  emitter.on('library:columns', updateColumns)
+
+  function updateColumns (col) {
+    localState.columns[col] = !localState.columns[col]
+    emitter.emit('render')
+  }
 
   function updateTrackDict (newTrackDict) {
     localState.trackDict = newTrackDict


### PR DESCRIPTION
columns can now be toggled on and off

caveats:

- does not persist when window is closed (should be moved to `persist` state)
- widths are sometimes wonky, need to rethink table css again (i have an idea already)

## screnshos

![screen shot 2017-09-17 at 11 47 01 am](https://user-images.githubusercontent.com/427322/30523858-036a1118-9b9e-11e7-99fa-b802c137a5ee.png)
![screen shot 2017-09-17 at 11 47 15 am](https://user-images.githubusercontent.com/427322/30523859-037c4e5a-9b9e-11e7-9148-8a243ba149b0.png)
