### PR TITLE
GPL-3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "music",
     "player"
   ],
-  "license": "ISC",
+  "license": "GPL-3.0",
   "main": "main/index.js",
   "productName": "Hyperamp",
   "repository": {


### PR DESCRIPTION
Lets us GPL-3.0 to avoid content flippers on the main app.  The rest of the submodules will remain MITesq.