### PR TITLE
Re-register media shortcuts when window activate

### DIFF
--- a/main/globalShortcuts.js
+++ b/main/globalShortcuts.js
@@ -1,0 +1,29 @@
+var { globalShortcut } = require('electron')
+
+class GlobalShortcuts {
+  construtor () {
+    this.actions = {}
+  }
+
+  init (actions = {}) {
+    this.actions = actions
+    this.register(actions)
+  }
+
+  register (actions) {
+    Object.entries(actions).forEach(entry => {
+      globalShortcut.register(entry[0], entry[1])
+    })
+  }
+
+  reregister () {
+    globalShortcut.unregisterAll()
+    this.register(this.actions)
+  }
+
+  unregisterAll () {
+    globalShortcut.unregisterAll()
+  }
+}
+
+module.exports = GlobalShortcuts


### PR DESCRIPTION
When other applications steal the media key registration away from hyperamp, this will grab it back when you activate the window.

Closes https://github.com/hypermodules/hyperamp/issues/202