### PR TITLE
Scroll to current index on window open

### DIFF
--- a/main/index.js
+++ b/main/index.js
@@ -204,8 +204,12 @@ app.on('ready', function appReady () {
 
   ipcMain.on('recall', recall)
 
-  ipcMain.on('sync-state', () => {
-    if (player.win) player.win.send('track-dict', al.trackDict, al.order, state.paths)
+  ipcMain.on('sync-state', (ev) => {
+    ev.sender.send('sync-state', {
+      trackDict: al.trackDict,
+      order: al.order,
+      paths: state.paths
+    })
   })
 
   setTimeout(() => {

--- a/renderer/stores/library.js
+++ b/renderer/stores/library.js
@@ -160,4 +160,14 @@ function libraryStore (state, emitter) {
     emitter.emit('render')
     trackView.scrollCurrent()
   })
+  ipcRenderer.on('sync-state', (ev, data) => {
+    var {trackDict, order, paths} = data
+    window.requestAnimationFrame(() => {
+      emitter.emit('library:track-dict', trackDict)
+      emitter.emit('library:track-order', order)
+      emitter.emit('library:paths', paths)
+      emitter.emit('render')
+      trackView.scrollCurrent()
+    })
+  })
 }


### PR DESCRIPTION
When opening the window, scroll to the current index.  I had to re-differentiate between updating tract dicts and initializing.  Its a mess but we can revisit all of the event organization when we have time.