### PR TITLE
Change state reference for progress indicator

### DIFF
--- a/renderer/elements/player/progress.js
+++ b/renderer/elements/player/progress.js
@@ -110,7 +110,7 @@ class Progress extends Component {
 
   update (state, emit) {
     this.emit = emit
-    if (this.disabled !== truthy(state.player.currentIndex)) return true
+    if (this.disabled !== truthy(state.library.currentIndex)) return true
     if (this.key !== get(state, 'player.currentTrack.key')) return true
     if (this.position !== state.player.currentTime) return true
     if (this.duration !== get(state, 'player.currentTrack.duration')) return true


### PR DESCRIPTION
Fixes #270.

This fix appears to solve the progress indicator issue for me on my Windows box. But I have not tested on any other OS. 

On master, the progress indicator range input gets a `disabled="disabled"` attribute. After review, I noticed the `update` method pointed to a non-existing (stale?) state reference which would cause the `disabled` attribute to be attached.

I'm not sure why this would work on other OSes, but not on Windows. 🤷‍♂️ 