### PR TITLE
fix(scanning): uncaught TypeError from missing "no" prop (#289)

### DIFF
--- a/main/lib/audio-library/sort.js
+++ b/main/lib/audio-library/sort.js
@@ -1,31 +1,44 @@
-function sort ([keyA, aObj], [keyB, bObj]) {
-      // sort by albumartist
-      // if (aObj.albumartist[0] < bObj.albumartist[0]) return -1
-      // if (aObj.albumartist[0] > bObj.albumartist[0]) return 1
+var existy = require('existy')
 
-      // sort by artist
+function sort ([keyA, aObj], [keyB, bObj]) {
+  // sort by albumartist
+  // if (aObj.albumartist[0] < bObj.albumartist[0]) return -1
+  // if (aObj.albumartist[0] > bObj.albumartist[0]) return 1
+
+  // sort by artist
   if (aObj.artist < bObj.artist) return -1
   if (aObj.artist > bObj.artist) return 1
 
-      // then by album
+  // then by album
   if (aObj.album < bObj.album) return -1
   if (aObj.album > bObj.album) return 1
 
-      // then by disc no
-  if (aObj.disk.no < bObj.disk.no) return -1
-  if (aObj.disk.no > bObj.disk.no) return 1
+  // then by disc no
+  var aHasDisk = existy(aObj.disk)
+  var bHasDisk = existy(bObj.disk)
 
-      // then by disc no
-  if (aObj.track.no < bObj.track.no) return -1
-  if (aObj.track.no > bObj.track.no) return 1
+  if (aHasDisk && bHasDisk) {
+    if (aObj.disk.no < bObj.disk.no) return -1
+    if (aObj.disk.no > bObj.disk.no) return 1
+  }
 
-      // then by title
+  // then by track no
+  var aHasTrack = existy(aObj.track)
+  var bHasTrack = existy(bObj.track)
+
+  if (aHasTrack && bHasTrack) {
+    if (aObj.track.no < bObj.track.no) return -1
+    if (aObj.track.no > bObj.track.no) return 1
+  }
+
+  // then by title
   if (aObj.title < bObj.title) return -1
   if (aObj.title > bObj.title) return 1
 
-      // then by filepath
+  // then by filepath
   if (aObj.filepath < bObj.filepath) return -1
   if (aObj.filepath > bObj.filepath) return 1
+
   return 0
 }
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "electron-updater": "^2.16.2",
     "electron-window-state": "^4.0.2",
     "entypo": "^2.1.0",
+    "existy": "^1.0.1",
     "file-url": "^2.0.2",
     "flush-write-stream": "^1.0.2",
     "folder-walker": "^3.0.0",


### PR DESCRIPTION
Resolves #289.

This appears to resolve the bug where scanning a file with missing track/disk metadata causes a silent failure.

Tested locally on macOS Sierra.