### PR TITLE
feat(playlist): add "Reveal in Finder" context menu option to tracks

### DIFF
--- a/renderer/elements/playlist/track-view.js
+++ b/renderer/elements/playlist/track-view.js
@@ -6,7 +6,7 @@ var document = require('global/document')
 var { formatCount } = require('./lib')
 var { COLUMNS } = require('../../lib/constants')
 var styles = require('./styles')
-const { Menu, MenuItem, getCurrentWindow } = require('electron').remote
+const { Menu, MenuItem, getCurrentWindow, shell } = require('electron').remote
 
 var OFFSET_BUFFER = 50
 
@@ -152,7 +152,10 @@ class TrackView extends Component {
     })
 
     return html`
-      <tr id="track-${idx + this.sliceStartIndex}" data-key=${key} class=${classes}>
+      <tr id="track-${idx + this.sliceStartIndex}"
+        data-key=${key}
+        class=${classes}
+        oncontextmenu=${trackMenu(track.filepath)}>
         ${columns.map(col => html`
           <td class=${styles[col]}>${meta[col]}</td>
         `)}
@@ -286,6 +289,19 @@ function shouldColumnsUpdate (cols, newCols) {
 
 function capitalize (string) {
   return string.charAt(0).toUpperCase() + string.slice(1)
+}
+
+function trackMenu (filepath) {
+  return function onTrackContextMenu (event) {
+    event.preventDefault()
+    const menu = new Menu()
+    menu.append(new MenuItem({
+      // TODO: show appropriate labels for windows & linux
+      label: 'Reveal in Finder',
+      click: () => shell.showItemInFolder(filepath)
+    }))
+    menu.popup(getCurrentWindow())
+  }
 }
 
 module.exports = TrackView


### PR DESCRIPTION
Adds "Reveal in Finder" context menu option to tracks in the playlist.
Overrides `electron-context-menu`.

<img width="474" alt="screen shot 2017-12-17 at 9 45 33 pm" src="https://user-images.githubusercontent.com/427322/34091609-acdadc42-e373-11e7-9fbc-cc6f18a1f707.png">
