### PR TITLE
fix(menu): do not strip "bugs" from package (#304)

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "concat-stream": "^1.6.0",
     "dependency-check": "^3.0.0",
     "electron": "1.8.2",
-    "electron-builder": "20.0.4",
+    "electron-builder": "20.0.8",
     "electron-renderify": "0.0.2",
     "envify": "^4.1.0",
     "is-buffer": "^2.0.0",


### PR DESCRIPTION
Fixed by bumping to `electron-builder@20.0.8`.

Packaged app tested locally with `npm run build`. "Report an issue" link now works fine.

Should be no breaking changes in `electron-builder` between `20.0.4` and `20.0.8`. 🤞 
See release notes: https://github.com/electron-userland/electron-builder/releases